### PR TITLE
Fix header flickering

### DIFF
--- a/app/assets/stylesheets/mainpage.scss
+++ b/app/assets/stylesheets/mainpage.scss
@@ -2,8 +2,8 @@
 // They will automatically be included in application.css.
 // You can use Sass (SCSS) here: http://sass-lang.com/
 #header {
-    position: sticky;
-    position: -webkit-sticky;
+    position: fixed;
+    width: 100%;
     top: 0;
     background: white;
     text-align: center;
@@ -28,6 +28,7 @@
     text-align: center;
     width: 96% !important;
     padding-bottom: 1rem;
+    margin-top: 130px;
 
     .restaurant {
         font-size: 0.7em;


### PR DESCRIPTION
Fixes header flickering by setting the header to fixed position and adding a margin to the main container.

Tested on Chrome and Firefox.